### PR TITLE
refactor: use unified kakao javascript key

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -38,11 +38,11 @@ export interface KakaoUserInfo {
 export const initKakao = () => {
   if (typeof window !== "undefined" && window.Kakao) {
     // Get JavaScript Key from environment variable
-    const kakaoKey = import.meta.env.VITE_KAKAO_JAVASCRIPT_KEY || import.meta.env.VITE_KAKAO_JS_KEY;
+    const kakaoKey = import.meta.env.KAKAO_JAVASCRIPT_KEY;
     console.log("Kakao key available:", !!kakaoKey, "Key length:", kakaoKey?.length);
-    
+
     if (!kakaoKey) {
-      console.error("VITE_KAKAO_JAVASCRIPT_KEY is not set");
+      console.error("KAKAO_JAVASCRIPT_KEY is not set");
       return;
     }
     

--- a/replit.md
+++ b/replit.md
@@ -7,7 +7,7 @@ This is a full-stack web application for the Dongguk University Korean Medicine 
 ### Authentication System
 - **Database Migration**: Successfully migrated from Neon to Supabase PostgreSQL 17.4
 - **Kakao Login Integration**: Configured custom Kakao login system with fallback development mode
-- **Environment Variables**: Set up VITE_KAKAO_JAVASCRIPT_KEY for client-side Kakao SDK
+- **Environment Variables**: Set up KAKAO_JAVASCRIPT_KEY for client-side Kakao SDK
 - **Domain Configuration**: Configured for Replit domain `https://dc5e5541-525b-4ad6-b914-2d2db70cb4a9-00-flpzugprplfl.spock.replit.dev`
 
 ### Legal Compliance


### PR DESCRIPTION
## Summary
- swap Kakao JS key env variable to `KAKAO_JAVASCRIPT_KEY`
- drop legacy `VITE_KAKAO_JS_KEY`
- update Replit docs for new variable name

## Testing
- `npm run check` *(fails: Property 'onMenuClick' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b409eb00bc83229f949dffdb7bdcd3